### PR TITLE
German localization for labels and tags

### DIFF
--- a/GUI/CKAN-GUI.csproj
+++ b/GUI/CKAN-GUI.csproj
@@ -299,6 +299,9 @@
     <EmbeddedResource Include="EditLabelsDialog.resx">
       <DependentUpon>EditLabelsDialog.cs</DependentUpon>
     </EmbeddedResource>
+    <EmbeddedResource Include="Localization\de-DE\EditLabelsDialog.de-DE.resx">
+      <DependentUpon>..\..\EditLabelsDialog.cs</DependentUpon>
+    </EmbeddedResource>
     <EmbeddedResource Include="ErrorDialog.resx">
       <DependentUpon>ErrorDialog.cs</DependentUpon>
     </EmbeddedResource>

--- a/GUI/Localization/de-DE/EditLabelsDialog.de-DE.resx
+++ b/GUI/Localization/de-DE/EditLabelsDialog.de-DE.resx
@@ -119,20 +119,20 @@
   </resheader>
   <assembly alias="System.Drawing" name="System.Drawing, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a" />
   <data name="CreateButton.Text" xml:space="preserve"><value>Erstellen</value></data>
-  <data name="SelectOrCreateLabel.Text" xml:space="preserve"><value>Wählen Sie eine Bezeichnung zum Bearbeiten oder erstellen Sie eine neue</value></data>
+  <data name="SelectOrCreateLabel.Text" xml:space="preserve"><value>Wähle ein Label zum Bearbeiten oder erstelle ein neues</value></data>
   <data name="NameLabel.Text" xml:space="preserve"><value>Name:</value></data>
   <data name="ColorLabel.Text" xml:space="preserve"><value>Hintergrund:</value></data>
-  <data name="ColorButton.Text" xml:space="preserve"><value>Wählen...</value></data>
-  <data name="InstanceNameLabel.Text" xml:space="preserve"><value>Beispiel
+  <data name="ColorButton.Text" xml:space="preserve"><value>Auswahl...</value></data>
+  <data name="InstanceNameLabel.Text" xml:space="preserve"><value>Instanz
 (leer für alle):</value></data>
-  <data name="HideFromOtherFiltersCheckBox.Text" xml:space="preserve"><value>Vor anderen Filtern verstecken</value></data>
-  <data name="NotifyOnChangesCheckBox.Text" xml:space="preserve"><value>Bei Updates benachrichtigen</value></data>
-  <data name="RemoveOnChangesCheckBox.Text" xml:space="preserve"><value>Bei Updates entfernen</value></data>
-  <data name="AlertOnInstallCheckBox.Text" xml:space="preserve"><value>Bei Installation benachrichtigen</value></data>
-  <data name="RemoveOnInstallCheckBox.Text" xml:space="preserve"><value>Bei der Installation entfernen</value></data>
+  <data name="HideFromOtherFiltersCheckBox.Text" xml:space="preserve"><value>In anderen Filtern verstecken</value></data>
+  <data name="NotifyOnChangesCheckBox.Text" xml:space="preserve"><value>Bei verfügbaren Upgrades benachrichtigen</value></data>
+  <data name="RemoveOnChangesCheckBox.Text" xml:space="preserve"><value>Label nach Updates entfernen</value></data>
+  <data name="AlertOnInstallCheckBox.Text" xml:space="preserve"><value>Vor Installation warnen</value></data>
+  <data name="RemoveOnInstallCheckBox.Text" xml:space="preserve"><value>Label nach der Installation entfernen</value></data>
   <data name="CloseButton.Text" xml:space="preserve"><value>Schließen</value></data>
   <data name="SaveButton.Text" xml:space="preserve"><value>Speichern</value></data>
-  <data name="CancelButton.Text" xml:space="preserve"><value>Stornieren</value></data>
-  <data name="DeleteButton.Text" xml:space="preserve"><value>Delete</value></data>
+  <data name="CancelButton.Text" xml:space="preserve"><value>Abbrechen</value></data>
+  <data name="DeleteButton.Text" xml:space="preserve"><value>Löschen</value></data>
   <data name="$this.Text" xml:space="preserve"><value>Labels bearbeiten</value></data>
 </root>

--- a/GUI/Localization/de-DE/Main.de-DE.resx
+++ b/GUI/Localization/de-DE/Main.de-DE.resx
@@ -195,6 +195,7 @@
   <data name="FilterNotInstalledButton.Text" xml:space="preserve"><value>Nicht installiert</value></data>
   <data name="FilterIncompatibleButton.Text" xml:space="preserve"><value>Inkompatibel</value></data>
   <data name="FilterAllButton.Text" xml:space="preserve"><value>Alle</value></data>
+  <data name="FilterTagsToolButton.Text" xml:space="preserve"><value>Kategorien</value></data>
   <data name="NavBackwardToolButton.ToolTipText" xml:space="preserve"><value>Zuvor ausgewählte Mod...</value></data>
   <data name="NavForwardToolButton.ToolTipText" xml:space="preserve"><value>Danach ausgewählte mod...</value></data>
   <data name="AutoInstalled.HeaderText" xml:space="preserve"><value>Auto-installiert</value></data>
@@ -251,6 +252,5 @@
   <data name="openKSPDirectoryToolStripMenuItem1.Text" xml:space="preserve"><value>KSP-Verzeichnis öffnen</value></data>
   <data name="cKANSettingsToolStripMenuItem1.Text" xml:space="preserve"><value>CKAN Einstellungen</value></data>
   <data name="quitToolStripMenuItem.Text" xml:space="preserve"><value>Beenden</value></data>
-  <data name="labelsToolStripMenuItem.Text" xml:space="preserve"><value>Etiketten</value></data>
-  <data name="editLabelsToolStripMenuItem.Text" xml:space="preserve"><value>Labels bearbeiten ...</value></data>
+  <data name="editLabelsToolStripMenuItem.Text" xml:space="preserve"><value>Labels bearbeiten...</value></data>
 </root>

--- a/GUI/Properties/Resources.de-DE.resx
+++ b/GUI/Properties/Resources.de-DE.resx
@@ -163,8 +163,8 @@
   <data name="MainFilterNotInstalled" xml:space="preserve"><value>Filter (Nicht installiert)</value></data>
   <data name="MainFilterCompatible" xml:space="preserve"><value>Filter (Kompatibel)</value></data>
   <data name="MainFilterLabel" xml:space="preserve"><value>Label ({0})</value></data>
-  <data name="MainFilterTag" xml:space="preserve"><value>Etikett ({0})</value></data>
-  <data name="MainFilterUntagged" xml:space="preserve"><value>Tag (Ohne Tag)</value></data>
+  <data name="MainFilterTag" xml:space="preserve"><value>Kategorie ({0})</value></data>
+  <data name="MainFilterUntagged" xml:space="preserve"><value>Kategorie (Keine)</value></data>
   <data name="MainLaunchWithIncompatible" xml:space="preserve">
     <value>Einige installierte Module sind inkompatibel! Es ist möglicherweise nicht sicher, KSP zu starten. Trotzdem starten?
 
@@ -320,27 +320,27 @@ Wenn du auf Nein klickst, siehst du diese Nachricht nicht mehr.</value>
   <data name="ModuleLabelListFavourites" xml:space="preserve"><value>Favoriten</value></data>
   <data name="ModuleLabelListHidden" xml:space="preserve"><value>Versteckt</value></data>
   <data name="ModuleLabelListGlobal" xml:space="preserve"><value>Global</value></data>
-  <data name="EditLabelsDialogConfirmDelete" xml:space="preserve"><value>Möchten Sie {0} wirklich löschen? Dies kann nicht rückgängig gemacht werden!</value></data>
+  <data name="EditLabelsDialogConfirmDelete" xml:space="preserve"><value>Möchtest du {0} wirklich löschen? Das kann nicht mehr rückgängig gemacht werden!</value></data>
   <data name="EditLabelsDialogSavePrompt" xml:space="preserve"><value>Änderungen speichern?</value></data>
-  <data name="EditLabelsDialogNoRecord" xml:space="preserve"><value>Es wird kein Datensatz bearbeitet!</value></data>
+  <data name="EditLabelsDialogNoRecord" xml:space="preserve"><value>Es wird gerade kein Label bearbeitet!</value></data>
   <data name="EditLabelsDialogNameRequired" xml:space="preserve"><value>Name ist erforderlich!</value></data>
   <data name="EditLabelsDialogAlreadyExists" xml:space="preserve"><value>{0} existiert bereits in {1}!</value></data>
   <data name="EditLabelsDialogDelete" xml:space="preserve"><value>Löschen</value></data>
-  <data name="EditLabelsDialogCancel" xml:space="preserve"><value>Stornieren</value></data>
+  <data name="EditLabelsDialogCancel" xml:space="preserve"><value>Abbrechen</value></data>
   <data name="EditLabelsDialogSave" xml:space="preserve"><value>Speichern</value></data>
-  <data name="EditLabelsDialogDiscard" xml:space="preserve"><value>Verwerfen</value></data>
-  <data name="MainChangesetWarningInstallingModuleWithLabel" xml:space="preserve"><value>WARNUNG: INSTALLIEREN MODULS MIT LABEL {0} ({1})</value></data>
-  <data name="EditLabelsToolTipName" xml:space="preserve"><value>Das Label wird im Menü Labels unter diesem Namen angezeigt und muss pro Installation eindeutig sein</value></data>
-  <data name="EditLabelsToolTipColor" xml:space="preserve"><value>Zeilen für Module mit dieser Bezeichnung werden mit dieser Hintergrundfarbe gezeichnet</value></data>
-  <data name="EditLabelsToolTipInstance" xml:space="preserve"><value>Die Instanz, für die dieses Label verfügbar ist, muss für alle leer gelassen werden</value></data>
-  <data name="EditLabelsToolTipHide" xml:space="preserve"><value>Wenn diese Option aktiviert ist, werden Module mit dieser Bezeichnung vor Standardfiltern verborgen</value></data>
-  <data name="EditLabelsToolTipNotifyOnChanges" xml:space="preserve"><value>Wenn diese Option aktiviert ist, wird eine Benachrichtigung angezeigt, wenn dieses Modul von inkompatibel zu kompatibel wechselt</value></data>
-  <data name="EditLabelsToolTipRemoveOnChanges" xml:space="preserve"><value>Wenn diese Option aktiviert ist, wird ein Modul, das von inkompatibel zu kompatibel wechselt, von diesem Label entfernt</value></data>
-  <data name="EditLabelsToolTipAlertOnInstall" xml:space="preserve"><value>Wenn diese Option aktiviert ist, werden Sie auf dem Bildschirm zum Festlegen von Änderungen benachrichtigt, wenn dieser Mod installiert wird</value></data>
-  <data name="EditLabelsToolTipRemoveOnInstall" xml:space="preserve"><value>Wenn diese Option aktiviert ist, werden Module von diesem Etikett entfernt, wenn sie installiert sind</value></data>
-  <data name="MainLabelsUpdateMessage" xml:space="preserve"><value>Einige deiner beobachteten Mods wurden aktualisiert:
+  <data name="EditLabelsDialogDiscard" xml:space="preserve"><value>Änderungen verwerfen</value></data>
+  <data name="MainChangesetWarningInstallingModuleWithLabel" xml:space="preserve"><value>WARNUNG: INSTALLATION EINES MODULS MIT LABEL {0} ({1})</value></data>
+  <data name="EditLabelsToolTipName" xml:space="preserve"><value>Das Label wird im Label-Menü unter diesem Namen angezeigt und muss in einer Instanz eindeutig sein</value></data>
+  <data name="EditLabelsToolTipColor" xml:space="preserve"><value>Module mit diesem Label werden haben diese Hintergrundfarbe in der Modliste</value></data>
+  <data name="EditLabelsToolTipInstance" xml:space="preserve"><value>Instanz, für welche dieses Label verfügbar ist. Leerlassen, um es in allen Instanzen verfügbar zu haben</value></data>
+  <data name="EditLabelsToolTipHide" xml:space="preserve"><value>Wenn diese Option aktiviert ist, werden Module mit diesem Label ausgeblendet</value></data>
+  <data name="EditLabelsToolTipNotifyOnChanges" xml:space="preserve"><value>Wenn diese Option aktiviert ist, wird eine Benachrichtigung angezeigt, sobald das Modul für deine KSP-Version kompatibel wird</value></data>
+  <data name="EditLabelsToolTipRemoveOnChanges" xml:space="preserve"><value>Wenn diese Option aktiviert ist, wird das Label von Modulen entfernt, sobald sie kompatibel werden</value></data>
+  <data name="EditLabelsToolTipAlertOnInstall" xml:space="preserve"><value>Wenn diese Option aktiviert ist, wird eine Warnung angezeigt, wenn das Modul installiert werden soll</value></data>
+  <data name="EditLabelsToolTipRemoveOnInstall" xml:space="preserve"><value>Wenn diese Option aktiviert ist, wird das Label von dem Modul entfernt, wenn es installiert wurde</value></data>
+  <data name="MainLabelsUpdateMessage" xml:space="preserve"><value>Mods die du beobachtest wurden aktualisiert:
 
 {0}</value></data>
-  <data name="MainLabelsUpdateTitle" xml:space="preserve"><value>Benachrichtigungen aktualisieren</value></data>
-  <data name="MainLabelsUntagged" xml:space="preserve"><value>Ohne Tags ({0})</value></data>
+  <data name="MainLabelsUpdateTitle" xml:space="preserve"><value>Aktualisierungen für beobachtete Mods</value></data>
+  <data name="MainLabelsUntagged" xml:space="preserve"><value>Ohne Kategorie ({0})</value></data>
 </root>


### PR DESCRIPTION
There it is. Nothing major I think.
You've forgot to add `Localization\de-DE\EditLabelsDialog.de-DE.resx` to the embedded resources (wondered why my IDE didn't show the file despite existing in the directory...), so I added  that too.