### PR TITLE
Move CheckDepends() candidates calculation in else stmt; Update code comments

### DIFF
--- a/Core/Net/Repo.cs
+++ b/Core/Net/Repo.cs
@@ -79,7 +79,7 @@ namespace CKAN
                     HandleModuleChanges(metadataChanges, user, ksp, cache);
                 }
 
-                // Registry.Available is slow, just return success,
+                // Registry.CompatibleModules is slow, just return success,
                 // caller can check it if it's really needed
                 return RepoUpdateResult.Updated;
             }
@@ -344,7 +344,7 @@ Do you wish to reinstall now?", sb)))
 
             ShowUserInconsistencies(registry_manager.registry, user);
 
-            // Registry.Available is slow, just return success,
+            // Registry.CompatibleModules is slow, just return success,
             // caller can check it if it's really needed
             return true;
         }

--- a/Core/Registry/IRegistryQuerier.cs
+++ b/Core/Registry/IRegistryQuerier.cs
@@ -16,7 +16,7 @@ namespace CKAN
         int? DownloadCount(string identifier);
 
         /// <summary>
-        /// Returns a simple array of all latest available modules for
+        /// Returns a simple array of the latest compatible module for each identifier for
         /// the specified version of KSP.
         /// </summary>
         IEnumerable<CkanModule> CompatibleModules(KspVersionCriteria ksp_version);
@@ -31,10 +31,9 @@ namespace CKAN
         string GetAvailableMetadata(string identifier);
 
         /// <summary>
-        ///     Returns the latest available version of a module that
-        ///     satisifes the specified version.
-        ///     Returns null if there's simply no compatible version for this system.
-        ///     If no ksp_version is provided, the latest module for *any* KSP is returned.
+        /// Returns the latest available version of a module that satisfies the specified version.
+        /// Returns null if there's simply no available version for this system.
+        /// If no ksp_version is provided, the latest module for *any* KSP version is returned.
         /// <exception cref="ModuleNotFoundKraken">Throws if asked for a non-existent module.</exception>
         /// </summary>
         CkanModule LatestAvailable(string identifier, KspVersionCriteria ksp_version, RelationshipDescriptor relationship_descriptor = null);
@@ -46,17 +45,17 @@ namespace CKAN
         KspVersion LatestCompatibleKSP(string identifier);
 
         /// <summary>
-        ///     Returns all available versions of a module.
+        /// Returns all available versions of a module.
         /// <exception cref="ModuleNotFoundKraken">Throws if asked for a non-existent module.</exception>
         /// </summary>
         IEnumerable<CkanModule> AvailableByIdentifier(string identifier);
 
         /// <summary>
-        ///     Returns the latest available version of a module that satisifes the specified version and
-        ///     optionally a RelationshipDescriptor. Takes into account module 'provides', which may
-        ///     result in a list of alternatives being provided.
-        ///     Returns an empty list if nothing is available for our system, which includes if no such module exists.
-        ///     If no KSP version is provided, the latest module for *any* KSP version is given.
+        /// Returns the latest available version of a module that satisfies the specified version and
+        /// optionally a RelationshipDescriptor. Takes into account module 'provides', which may
+        /// result in a list of alternatives being provided.
+        /// Returns an empty list if nothing is available for our system, which includes if no such module exists.
+        /// If no KSP version is provided, the latest module for *any* KSP version is given.
         /// </summary>
         List<CkanModule> LatestAvailableWithProvides(
             string                  identifier,
@@ -66,8 +65,8 @@ namespace CKAN
         );
 
         /// <summary>
-        ///     Checks the sanity of the registry, to ensure that all dependencies are met,
-        ///     and no mods conflict with each other.
+        /// Checks the sanity of the registry, to ensure that all dependencies are met,
+        /// and no mods conflict with each other.
         /// <exception cref="InconsistentKraken">Thrown if a inconsistency is found</exception>
         /// </summary>
         void CheckSanity();
@@ -102,8 +101,8 @@ namespace CKAN
         CkanModule GetModuleByVersion(string identifier, ModuleVersion version);
 
         /// <summary>
-        ///     Returns a simple array of all incompatible modules for
-        ///     the specified version of KSP.
+        /// Returns a simple array of all incompatible modules for
+        /// the specified version of KSP.
         /// </summary>
         IEnumerable<CkanModule> IncompatibleModules(KspVersionCriteria ksp_version);
 


### PR DESCRIPTION
Some more suggestions / changes for https://github.com/KSP-CKAN/CKAN/pull/2963:
1) Move the LINQ statement to calculate the candidates in `CheckDepends()` into the else part where it is actually needed to save some cycles in very few cases.
I also added a comment to it because it took me quite some time to figure out what it actually does and how it works. Maybe this helps others looking at the code in the future (or myself because I'm sure I'll have forgotten it again)
2) Updated some comments to reflect the change from `Registry.Available` -> `Registry.CompatibleModules`