### PR TITLE
Clean up unused import statements

### DIFF
--- a/GUI/ControlFactory.cs
+++ b/GUI/ControlFactory.cs
@@ -3,14 +3,12 @@ using System.Threading;
 
 namespace CKAN
 {
-
-    // this class ensures that all controls are created from the same thread
-    // this is a mono limitation described here - http://www.mono-project.com/docs/faq/winforms/
-
-
+    /// <summary>
+    /// This class ensures that all controls are created from the same thread.
+    /// This is a mono limitation described here - http://www.mono-project.com/docs/faq/winforms/
+    /// </summary>
     public class ControlFactory
     {
-
         private int m_MainThreadID;
 
         public ControlFactory()
@@ -27,8 +25,5 @@ namespace CKAN
 
             return new T();
         }
-        
-
     }
-
 }

--- a/GUI/Controls/AllModVersions.cs
+++ b/GUI/Controls/AllModVersions.cs
@@ -1,7 +1,6 @@
 using System.ComponentModel;
 using System.Collections.Generic;
 using System.Drawing;
-using System.Data;
 using System.Linq;
 using System.Windows.Forms;
 using CKAN.Versioning;
@@ -40,7 +39,7 @@ namespace CKAN
                         e.NewValue = CheckState.Unchecked;
                     }
                     break;
-                
+
                 case CheckState.Unchecked:
                     // Remove or cancel installation
                     visibleGuiModule.SelectedMod = null;
@@ -56,7 +55,7 @@ namespace CKAN
                     Properties.Resources.AllModVersionsInstallYes,
                     Properties.Resources.AllModVersionsInstallNo);
         }
-        
+
         private void visibleGuiModule_PropertyChanged(object sender, PropertyChangedEventArgs e)
         {
             switch (e.PropertyName)

--- a/GUI/Controls/Changeset.cs
+++ b/GUI/Controls/Changeset.cs
@@ -1,5 +1,4 @@
 using System;
-using System.IO;
 using System.Linq;
 using System.Drawing;
 using System.Collections.Generic;

--- a/GUI/Controls/ChooseProvidedMods.cs
+++ b/GUI/Controls/ChooseProvidedMods.cs
@@ -1,10 +1,8 @@
 using System;
-using System.IO;
 using System.Linq;
 using System.Threading.Tasks;
 using System.Collections.Generic;
 using System.Windows.Forms;
-using CKAN.Extensions;
 
 namespace CKAN
 {

--- a/GUI/Controls/ChooseRecommendedMods.cs
+++ b/GUI/Controls/ChooseRecommendedMods.cs
@@ -1,8 +1,7 @@
 using System;
-using System.IO;
+using System.Collections.Generic;
 using System.Linq;
 using System.Threading.Tasks;
-using System.Collections.Generic;
 using System.Windows.Forms;
 using CKAN.Extensions;
 

--- a/GUI/Controls/DropdownMenuButton.cs
+++ b/GUI/Controls/DropdownMenuButton.cs
@@ -1,4 +1,3 @@
-using System;
 using System.ComponentModel;
 using System.Drawing;
 using System.Windows.Forms;

--- a/GUI/Controls/ModInfo.cs
+++ b/GUI/Controls/ModInfo.cs
@@ -1,11 +1,9 @@
 using System;
 using System.Linq;
 using System.Collections.Generic;
-using System.ComponentModel;
 using System.Drawing;
 using System.Windows.Forms;
 using System.IO;
-using System.Threading.Tasks;
 using CKAN.Versioning;
 
 namespace CKAN

--- a/GUI/Controls/ThemedListView.cs
+++ b/GUI/Controls/ThemedListView.cs
@@ -1,5 +1,3 @@
-using System;
-using System.Collections.Generic;
 using System.Drawing;
 using System.Windows.Forms;
 

--- a/GUI/Controls/ThemedTabControl.cs
+++ b/GUI/Controls/ThemedTabControl.cs
@@ -1,4 +1,3 @@
-using System;
 using System.Drawing;
 using System.Windows.Forms;
 

--- a/GUI/Controls/TransparentTextBox.cs
+++ b/GUI/Controls/TransparentTextBox.cs
@@ -1,5 +1,4 @@
-﻿using System;
-namespace CKAN
+﻿namespace CKAN
 {
     /// <summary>
     /// Create a new TransparentTextBox control that allows the backcolor of textboxes to be transparent.

--- a/GUI/Controls/Wait.cs
+++ b/GUI/Controls/Wait.cs
@@ -1,10 +1,5 @@
 using System;
-using System.IO;
-using System.Linq;
-using System.Threading.Tasks;
-using System.Collections.Generic;
 using System.Windows.Forms;
-using CKAN.Extensions;
 
 namespace CKAN
 {

--- a/GUI/Dialogs/EditLabelsDialog.cs
+++ b/GUI/Dialogs/EditLabelsDialog.cs
@@ -1,6 +1,5 @@
 using System;
 using System.Linq;
-using System.Collections.Generic;
 using System.Drawing;
 using System.Windows.Forms;
 using log4net;

--- a/GUI/Dialogs/KSPCommandLineOptionsDialog.cs
+++ b/GUI/Dialogs/KSPCommandLineOptionsDialog.cs
@@ -24,5 +24,4 @@ namespace CKAN
             return AdditionalArguments.Text;
         }
     }
-
 }

--- a/GUI/Dialogs/SettingsDialog.cs
+++ b/GUI/Dialogs/SettingsDialog.cs
@@ -1,9 +1,7 @@
 using System;
-using System.Diagnostics;
 using System.Collections.Generic;
 using System.Windows.Forms;
 using System.Drawing;
-using System.Linq;
 using CKAN.Versioning;
 using log4net;
 using CKAN.Configuration;

--- a/GUI/Dialogs/YesNoDialog.cs
+++ b/GUI/Dialogs/YesNoDialog.cs
@@ -1,6 +1,5 @@
-using System;
 using System.Drawing;
-﻿using System.Windows.Forms;
+using System.Windows.Forms;
 
 namespace CKAN
 {

--- a/GUI/FormCompatibility.cs
+++ b/GUI/FormCompatibility.cs
@@ -15,10 +15,8 @@ namespace CKAN
         {
             if (!Platform.IsWindows)
             {
-                ClientSize = new Size(ClientSize.Width, ClientSize.Height + formHeightDifference);      
+                ClientSize = new Size(ClientSize.Width, ClientSize.Height + formHeightDifference);
             }
         }
-
     }
-
 }

--- a/GUI/GUIUser.cs
+++ b/GUI/GUIUser.cs
@@ -1,5 +1,3 @@
-using System;
-
 namespace CKAN
 {
     /// <summary>
@@ -78,5 +76,4 @@ namespace CKAN
             main.AddStatusMessage(message, args);
         }
     }
-
 }

--- a/GUI/Labels/ModuleLabel.cs
+++ b/GUI/Labels/ModuleLabel.cs
@@ -1,5 +1,3 @@
-using System;
-using System.Linq;
 using System.Drawing;
 using System.ComponentModel;
 using System.Collections.Generic;

--- a/GUI/Main/MainChangeset.cs
+++ b/GUI/Main/MainChangeset.cs
@@ -1,16 +1,11 @@
-using System;
 using System.Linq;
 using System.Collections.Generic;
-using System.Drawing;
-using System.ComponentModel;
 using System.Windows.Forms;
-using CKAN.Extensions;
 
 namespace CKAN
 {
     public partial class Main
     {
-
         public void UpdateChangesDialog(List<ModChange> changeset)
         {
             Changeset.LoadChangeset(
@@ -60,6 +55,5 @@ namespace CKAN
                 mod.SetReplaceChecked(row, ReplaceCol, false);
             }
         }
-
     }
 }

--- a/GUI/Main/MainDialogs.cs
+++ b/GUI/Main/MainDialogs.cs
@@ -1,5 +1,4 @@
 ﻿using System;
-using System.Threading.Tasks;
 using System.Windows.Forms;
 
 namespace CKAN

--- a/GUI/Main/MainDownload.cs
+++ b/GUI/Main/MainDownload.cs
@@ -78,6 +78,5 @@ namespace CKAN
             // User might have selected another row. Show current in tree.
             UpdateModContentsTree(ModInfo.SelectedModule.ToCkanModule(), true);
         }
-
     }
 }

--- a/GUI/Main/MainImport.cs
+++ b/GUI/Main/MainImport.cs
@@ -5,10 +5,8 @@ using System.Windows.Forms;
 
 namespace CKAN
 {
-
     public partial class Main
     {
-
         private void importDownloadsToolStripMenuItem_Click(object sender, EventArgs e)
         {
             ImportModules();
@@ -80,7 +78,5 @@ namespace CKAN
             }
             return gameInst.GameDir();
         }
-
     }
-
 }

--- a/GUI/Main/MainInstall.cs
+++ b/GUI/Main/MainInstall.cs
@@ -1,14 +1,9 @@
 ﻿using System;
 using System.IO;
-using System.Diagnostics;
 using System.Collections.Generic;
 using System.ComponentModel;
 using System.Linq;
-using System.Threading;
-using System.Threading.Tasks;
-using System.Windows.Forms;
 using CKAN.Extensions;
-using CKAN.Types;
 
 namespace CKAN
 {
@@ -428,6 +423,5 @@ namespace CKAN
             Util.Invoke(this, () => Enabled = true);
             Util.Invoke(menuStrip1, () => menuStrip1.Enabled = true);
         }
-
     }
 }

--- a/GUI/Main/MainLabels.cs
+++ b/GUI/Main/MainLabels.cs
@@ -1,6 +1,5 @@
 using System;
 using System.Linq;
-using System.ComponentModel;
 using System.Windows.Forms;
 using System.Collections.Generic;
 using CKAN.Extensions;
@@ -17,7 +16,7 @@ namespace CKAN
             FilterTagsToolButton_DropDown_Opening(null, null);
             FilterLabelsToolButton_DropDown_Opening(null, null);
         }
-        
+
         private void FilterTagsToolButton_DropDown_Opening(object sender, System.ComponentModel.CancelEventArgs e)
         {
             FilterTagsToolButton.DropDownItems.Clear();

--- a/GUI/Main/MainModList.cs
+++ b/GUI/Main/MainModList.cs
@@ -1,6 +1,5 @@
 ﻿using System;
 using System.Drawing;
-using System.Diagnostics;
 using System.Collections.Generic;
 using System.Collections.ObjectModel;
 using System.Linq;
@@ -9,7 +8,6 @@ using System.Reflection;
 using System.Text.RegularExpressions;
 using System.Windows.Forms;
 using CKAN.Versioning;
-using log4net;
 
 namespace CKAN
 {
@@ -275,9 +273,9 @@ namespace CKAN
 
                 UpdateAllToolButton.Enabled = has_any_updates;
             });
-            
+
             (registry as Registry)?.BuildTagIndex(mainModList.ModuleTags);
-            
+
             UpdateFilters(this);
 
             // Hide update and replacement columns if not needed.
@@ -385,7 +383,7 @@ namespace CKAN
                     })
                     .ToArray()
                 );
-                
+
                 // Separator
                 ModListHeaderContextMenuStrip.Items.Add(new ToolStripSeparator());
 
@@ -734,7 +732,7 @@ namespace CKAN
 
         public readonly ModuleLabelList ModuleLabels = ModuleLabelList.Load(ModuleLabelList.DefaultPath)
             ?? ModuleLabelList.GetDefaultLabels();
-            
+
         public readonly ModuleTagList ModuleTags = ModuleTagList.Load(ModuleTagList.DefaultPath)
             ?? new ModuleTagList();
 
@@ -1054,7 +1052,7 @@ namespace CKAN
 
             return item;
         }
-        
+
         public Color GetRowBackground(GUIMod mod, bool conflicted, string instanceName)
         {
             if (conflicted)

--- a/GUI/Main/MainProvides.cs
+++ b/GUI/Main/MainProvides.cs
@@ -1,14 +1,9 @@
-using System;
-using System.Linq;
-using System.Threading.Tasks;
-using System.Collections.Concurrent;
 using System.Windows.Forms;
 
 namespace CKAN
 {
     public partial class Main
     {
-
         private void ChooseProvidedMods_OnSelectedItemsChanged(ListView.SelectedListViewItemCollection items)
         {
             ShowSelectionModInfo(items);
@@ -21,6 +16,5 @@ namespace CKAN
             tabController.SetTabLock(true);
             return ChooseProvidedMods.Wait();
         }
-
-	}
+    }
 }

--- a/GUI/Main/MainRecommendations.cs
+++ b/GUI/Main/MainRecommendations.cs
@@ -1,7 +1,6 @@
 using System;
 using System.Collections.Generic;
 using System.Windows.Forms;
-using System.Threading;
 using System.Threading.Tasks;
 using System.Linq;
 using CKAN.Extensions;
@@ -13,7 +12,6 @@ namespace CKAN
 
     public partial class Main
     {
-
         private void ChooseRecommendedMods_OnSelectedItemsChanged(ListView.SelectedListViewItemCollection items)
         {
             ShowSelectionModInfo(items);
@@ -62,6 +60,5 @@ namespace CKAN
                 currentUser.RaiseError(Properties.Resources.MainRecommendationsNoneFound);
             }
         }
-
     }
 }

--- a/GUI/Main/MainRepo.cs
+++ b/GUI/Main/MainRepo.cs
@@ -1,7 +1,6 @@
 ﻿using System;
 using System.Collections.Generic;
 using System.ComponentModel;
-using System.Net;
 using System.Timers;
 using System.Linq;
 using Newtonsoft.Json;
@@ -11,7 +10,6 @@ using Autofac;
 
 namespace CKAN
 {
-
     public partial class Main
     {
         private BackgroundWorker m_UpdateRepoWorker;
@@ -68,7 +66,7 @@ namespace CKAN
             {
                 AddStatusMessage(Properties.Resources.MainRepoScanning);
                 bool scanChanged = CurrentInstance.ScanGameData();
-    
+
                 AddStatusMessage(Properties.Resources.MainRepoUpdating);
 
                 // Note the current mods' compatibility for the NewlyCompatible filter
@@ -224,6 +222,5 @@ namespace CKAN
                 )
             );
         }
-
     }
 }

--- a/GUI/Main/MainTabControl.cs
+++ b/GUI/Main/MainTabControl.cs
@@ -1,12 +1,9 @@
 ﻿using System;
-using System.Windows.Forms;
 
 namespace CKAN
 {
     public class MainTabControl : ThemedTabControl
     {
-        public MainTabControl() : base() { }
-
         protected override void OnSelectedIndexChanged(EventArgs e)
         {
             base.OnSelectedIndexChanged(e);

--- a/GUI/Main/MainTrayIcon.cs
+++ b/GUI/Main/MainTrayIcon.cs
@@ -126,6 +126,5 @@ namespace CKAN
         }
 
         #endregion
-
     }
 }

--- a/GUI/Main/MainWait.cs
+++ b/GUI/Main/MainWait.cs
@@ -87,6 +87,5 @@ namespace CKAN
                 cancelCallback();
             }
         }
-
     }
 }

--- a/GUI/Model/ExportOption.cs
+++ b/GUI/Model/ExportOption.cs
@@ -16,7 +16,7 @@ namespace CKAN
             FriendlyName = friendlyName;
             Extension = extension;
 
-            _string = string.Format("{0}|{1}", FriendlyName, "*." + Extension);
+            _string = $"{FriendlyName}|*.{Extension}";
         }
 
         public override string ToString()

--- a/GUI/Model/GUIConfiguration.cs
+++ b/GUI/Model/GUIConfiguration.cs
@@ -5,7 +5,6 @@ using System.Collections.Generic;
 
 namespace CKAN
 {
-
     [XmlRootAttribute("Configuration")]
     public class GUIConfiguration
     {

--- a/GUI/Model/GUIMod.cs
+++ b/GUI/Model/GUIMod.cs
@@ -447,6 +447,5 @@ namespace CKAN
         {
             return $"{ToModule()}";
         }
-
     }
 }

--- a/GUI/Program.cs
+++ b/GUI/Program.cs
@@ -7,7 +7,7 @@ namespace CKAN
     public static class GUI
     {
         /// <summary>
-        ///     The main entry point for the application.
+        /// The main entry point for the application.
         /// </summary>
         [STAThread]
         public static void Main(string[] args)
@@ -25,7 +25,7 @@ namespace CKAN
 
             if (args.Contains(URLHandlers.UrlRegistrationArgument))
             {
-                //Passing in null will cause a NullRefrenceException if it tries to show the dialog
+                //Passing in null will cause a NullReferenceException if it tries to show the dialog
                 //asking for elevation permission, but we want that to happen. Doing that keeps us
                 //from getting in to a infinite loop of trying to register.
                 URLHandlers.RegisterURLHandler(null, null);

--- a/GUI/SingleAssemblyResourceManager.cs
+++ b/GUI/SingleAssemblyResourceManager.cs
@@ -1,6 +1,4 @@
-using System;
 using System.IO;
-using System.ComponentModel;
 using System.Globalization;
 using System.Resources;
 using System.Collections;

--- a/GUI/URLHandlers.cs
+++ b/GUI/URLHandlers.cs
@@ -199,7 +199,5 @@ namespace CKAN
             parser.WriteFile(handlerPath, data);
             AutoUpdate.SetExecutable(handlerPath);
         }
-
     }
-
 }

--- a/GUI/Util.cs
+++ b/GUI/Util.cs
@@ -1,7 +1,5 @@
 using System;
-﻿using System.Windows.Forms;
 using System.Collections.Generic;
-using System.Diagnostics;
 using System.Linq;
 using System.Drawing;
 
@@ -211,6 +209,5 @@ namespace CKAN
             // then place our window at an offset within the box
             return ClampedLocation(location - topLeftMargin, size + topLeftMargin + bottomRightMargin, screen) + topLeftMargin;
         }
-
     }
 }

--- a/Netkan/Transformers/AvcTransformer.cs
+++ b/Netkan/Transformers/AvcTransformer.cs
@@ -114,8 +114,8 @@ namespace CKAN.NetKAN.Transformers
             var existingKspMax = existingKspMaxStr == null ? null : KspVersion.Parse(existingKspMaxStr);
 
             // Get the minimum and maximum KSP versions that are in the AVC file.
-            // http://ksp.cybutek.net/kspavc/Documents/README.htm
-            // KSP-AVC allows (requires?) KSP_VERSION to be set
+            // https://github.com/linuxgurugamer/KSPAddonVersionChecker/blob/master/KSP-AVC.schema.json
+            // KSP-AVC allows KSP_VERSION to be set
             // when KSP_VERSION_MIN/_MAX are set, but CKAN treats
             // its equivalent properties as mutually exclusive.
             // Only fallback if neither min nor max are defined,


### PR DESCRIPTION
https://github.com/KSP-CKAN/CKAN/pull/2966 moved a lot of code around, often in new files.
These new files have a lot of unused import statements copied forward from where the code was originally.

Since I've removed a lot of them along the way when reviewing the PR, I just take the opportunity to do a PR to your branch.

There are also some smaller changes like removing blank lines between curly brackets.

Probably the "biggest" change is changing the link of a comment in NetKAN'S AVC version parsing logic from CYBUTEK's website to the new spec file in the AVC repo.