### PR TITLE
German localization for new modpack functionality

### DIFF
--- a/GUI/Localization/de-DE/EditModpack.de-DE.resx
+++ b/GUI/Localization/de-DE/EditModpack.de-DE.resx
@@ -120,21 +120,21 @@
   <data name="IdentifierLabel.Text" xml:space="preserve"><value>Kennung:</value></data>
   <data name="NameLabel.Text" xml:space="preserve"><value>Name:</value></data>
   <data name="AbstractLabel.Text" xml:space="preserve"><value>Abstrakt:</value></data>
-  <data name="VersionLabel.Text" xml:space="preserve"><value>Ausführung:</value></data>
+  <data name="VersionLabel.Text" xml:space="preserve"><value>Modpack-Version:</value></data>
   <data name="KspVersionLabel.Text" xml:space="preserve"><value>KSP-Versionen:</value></data>
   <data name="LicenseLabel.Text" xml:space="preserve"><value>Lizenz:</value></data>
-  <data name="IncludeVersionsCheckbox.Text" xml:space="preserve"><value>Speichern Sie Mod-Versionen</value></data>
+  <data name="IncludeVersionsCheckbox.Text" xml:space="preserve"><value>Mod-Versionen im Pack auf die hier angezeigten festsetzen</value></data>
   <data name="ModNameColumn.Text" xml:space="preserve"><value>Mod</value></data>
-  <data name="ModVersionColumn.Text" xml:space="preserve"><value>Ausführung</value></data>
+  <data name="ModVersionColumn.Text" xml:space="preserve"><value>Version</value></data>
   <data name="ModAbstractColumn.Text" xml:space="preserve"><value>Beschreibung</value></data>
-  <data name="DependsGroup.Header" xml:space="preserve"><value>Abhängigkeit</value></data>
-  <data name="RecommendationsGroup.Header" xml:space="preserve"><value>Empfiehlt</value></data>
-  <data name="SuggestionsGroup.Header" xml:space="preserve"><value>Schlägt</value></data>
-  <data name="IgnoredGroup.Header" xml:space="preserve"><value>Ignoriert</value></data>
+  <data name="DependsGroup.Header" xml:space="preserve"><value>Abhängigkeiten</value></data>
+  <data name="RecommendationsGroup.Header" xml:space="preserve"><value>Empgehlungen</value></data>
+  <data name="SuggestionsGroup.Header" xml:space="preserve"><value>Vorschläge</value></data>
+  <data name="IgnoredGroup.Header" xml:space="preserve"><value>Nicht Teil des Modpacks</value></data>
   <data name="DependsRadioButton.Text" xml:space="preserve"><value>Abhängigkeit</value></data>
-  <data name="RecommendsRadioButton.Text" xml:space="preserve"><value>Empfiehlt</value></data>
-  <data name="SuggestsRadioButton.Text" xml:space="preserve"><value>Schlägt</value></data>
-  <data name="IgnoreRadioButton.Text" xml:space="preserve"><value>Ignoriert</value></data>
-  <data name="CancelExportButton.Text" xml:space="preserve"><value>Stornieren</value></data>
-  <data name="ExportModpackButton.Text" xml:space="preserve"><value>Export</value></data>
+  <data name="RecommendsRadioButton.Text" xml:space="preserve"><value>Empfehlung</value></data>
+  <data name="SuggestsRadioButton.Text" xml:space="preserve"><value>Vorschlag</value></data>
+  <data name="IgnoreRadioButton.Text" xml:space="preserve"><value>Ausschließen</value></data>
+  <data name="CancelExportButton.Text" xml:space="preserve"><value>Abbrechen</value></data>
+  <data name="ExportModpackButton.Text" xml:space="preserve"><value>Exportieren</value></data>
 </root>

--- a/GUI/Localization/de-DE/Main.de-DE.resx
+++ b/GUI/Localization/de-DE/Main.de-DE.resx
@@ -167,7 +167,7 @@
   <data name="manageKspInstancesMenuItem.Text" xml:space="preserve"><value>KSP-Instanzen verwalten</value></data>
   <data name="openKspDirectoryToolStripMenuItem.Text" xml:space="preserve"><value>Spieleverzeichnis öffnen</value></data>
   <data name="installFromckanToolStripMenuItem.Text" xml:space="preserve"><value>Von .ckan installieren</value></data>
-  <data name="exportModListToolStripMenuItem.Text" xml:space="preserve"><value>Installierte Mod-Liste speichern ...</value></data>
+  <data name="exportModListToolStripMenuItem.Text" xml:space="preserve"><value>Liste installierter Mods speichern...</value></data>
   <data name="exportModPackToolStripMenuItem.Text" xml:space="preserve"><value>Modpack exportieren ...</value></data>
   <data name="importDownloadsToolStripMenuItem.Text" xml:space="preserve"><value>Heruntergeladene Mods &amp;importieren</value></data>
   <data name="auditRecommendationsMenuItem.Text" xml:space="preserve"><value>Empfehlungen installierter Mods</value></data>
@@ -225,21 +225,7 @@
   <data name="ChangesetTabPage.Text" xml:space="preserve"><value>Änderungen</value></data>
   <data name="WaitTabPage.Text" xml:space="preserve"><value>Statuslog</value></data>
   <data name="ChooseRecommendedModsTabPage.Text" xml:space="preserve"><value>Wähle Empfehlungen und Vorschläge aus</value></data>
-  <data name="RecommendedModsCancelButton.Text" xml:space="preserve"><value>Abbrechen</value></data>
-  <data name="RecommendedModsContinueButton.Text" xml:space="preserve"><value>Fortsetzen</value></data>
-  <data name="RecommendedModsToggleCheckbox.Text" xml:space="preserve"><value>Alle Empfehlungen und Vorschläge ab-/auswählen</value></data>
-  <data name="RecommendedDialogLabel.Text" xml:space="preserve"><value>Die folgenden Module wurden von mindestens einer ausgewählten Mod empfohlen oder vorgeschlagen</value></data>
-  <data name="RecommendationsGroup.Header" xml:space="preserve"><value>Empfehlungen</value></data>
-  <data name="SuggestionsGroup.Header" xml:space="preserve"><value>Vorschläge</value></data>
-  <data name="SupportedByGroup.Header" xml:space="preserve"><value>Unterstützt durch</value></data>
-  <data name="columnHeader4.Text" xml:space="preserve"><value>Empfohlen/vorgeschlagen von:</value></data>
-  <data name="columnHeader5.Text" xml:space="preserve"><value>Kurzbeschreibung</value></data>
-  <data name="ChooseProvidedModsTabPage.Text" xml:space="preserve"><value>Wähle Mods</value></data>
-  <data name="ChooseProvidedModsCancelButton.Text" xml:space="preserve"><value>Abbrechen</value></data>
-  <data name="ChooseProvidedModsContinueButton.Text" xml:space="preserve"><value>Fortfahren</value></data>
-  <data name="columnHeader8.Text" xml:space="preserve"><value>Kurzbeschreibung der Mod</value></data>
-  <data name="ChooseProvidedModsLabel.Text" xml:space="preserve"><value>Mehrere Mods stellen das virtuelle Modul Foo zur Verfügung, wähle eine der folgenden Mods:</value></data>
-  <data name="EditModpackTabPage.Text" xml:space="preserve"><value>Bearbeiten Sie Modpack</value></data>
+  <data name="EditModpackTabPage.Text" xml:space="preserve"><value>Modpack bearbeiten</value></data>
   <data name="updatesToolStripMenuItem.Text" xml:space="preserve"><value>N verfügbare Updates</value></data>
   <data name="refreshToolStripMenuItem.Text" xml:space="preserve"><value>Aktualisieren</value></data>
   <data name="pauseToolStripMenuItem.Text" xml:space="preserve"><value>Anhalten</value></data>

--- a/GUI/Properties/Resources.de-DE.resx
+++ b/GUI/Properties/Resources.de-DE.resx
@@ -342,22 +342,22 @@ Wenn du auf Nein klickst, siehst du diese Nachricht nicht mehr.</value>
 {0}</value></data>
   <data name="MainLabelsUpdateTitle" xml:space="preserve"><value>Aktualisierungen für beobachtete Mods</value></data>
   <data name="MainLabelsUntagged" xml:space="preserve"><value>Ohne Kategorie ({0})</value></data>
-  <data name="EditModpackBadIdentifier" xml:space="preserve"><value>Der Bezeichner muss mindestens einen Buchstaben, eine Ziffer und einen Bindestrich enthalten und mit einem Buchstaben oder einer Ziffer beginnen</value></data>
-  <data name="EditModpackBadName" xml:space="preserve"><value>Name ist erforderlich</value></data>
-  <data name="EditModpackBadVersion" xml:space="preserve"><value>Version ist erforderlich</value></data>
-  <data name="EditModpackBadKspVersions" xml:space="preserve"><value>Die minimale KSP-Version muss kleiner oder gleich der maximalen KSP-Version sein</value></data>
-  <data name="EditModpackTooltipIdentifier" xml:space="preserve"><value>Interner Name dieses Modpacks; Nur Buchstaben, Zahlen und Bindestriche</value></data>
+  <data name="EditModpackBadIdentifier" xml:space="preserve"><value>Die Kennung darf nur aus Buchstaben, Zahlen und Bindestrichen bestehen, muss mindestens zwei Zeichen lang sein und darf nicht mit einem Bindestrich beginnen.</value></data>
+  <data name="EditModpackBadName" xml:space="preserve"><value>Ein Name für das Modpack ist erforderlich.</value></data>
+  <data name="EditModpackBadVersion" xml:space="preserve"><value>Eine Version für das Modpack ist erforderlich.</value></data>
+  <data name="EditModpackBadKspVersions" xml:space="preserve"><value>Die minimale KSP-Version muss kleiner oder gleich der maximalen KSP-Version sein.</value></data>
+  <data name="EditModpackTooltipIdentifier" xml:space="preserve"><value>Interne Kennung dieses Modpacks; Nur Buchstaben, Zahlen und Bindestriche</value></data>
   <data name="EditModpackTooltipName" xml:space="preserve"><value>Öffentlich sichtbarer Name dieses Modpacks</value></data>
-  <data name="EditModpackTooltipAbstract" xml:space="preserve"><value>Lange Beschreibung dieses Modpacks</value></data>
-  <data name="EditModpackTooltipVersion" xml:space="preserve"><value>Die Versionsnummer für dieses Modpack</value></data>
-  <data name="EditModpackTooltipKspVersionMin" xml:space="preserve"><value>Früheste kompatible Version von KSP, leer für alle</value></data>
-  <data name="EditModpackTooltipKspVersionMax" xml:space="preserve"><value>Neueste kompatible Version von KSP, leer für alle</value></data>
+  <data name="EditModpackTooltipAbstract" xml:space="preserve"><value>Kurze Zusammenfassung dieses Modpacks</value></data>
+  <data name="EditModpackTooltipVersion" xml:space="preserve"><value>Die Versionsnummer für dieses Modpack, nutze das heutige Datum um es später einfach zuordnen zu können.</value></data>
+  <data name="EditModpackTooltipKspVersionMin" xml:space="preserve"><value>Setze die früheste KSP-Version fest, unter der das Modpack installiert werden kann. Leer für unbeschränkt.</value></data>
+  <data name="EditModpackTooltipKspVersionMax" xml:space="preserve"><value>Setze die neusete KSP-Version fest, unter der das Modpack installiert werden kann. Leer für unbeschränkt.</value></data>
   <data name="EditModpackTooltipLicense" xml:space="preserve"><value>Die Lizenz für dieses Modpack</value></data>
-  <data name="EditModpackTooltipIncludeVersions" xml:space="preserve"><value>Wenn diese Option aktiviert ist, enthält das Modpack die spezifischen Versionen der angezeigten Mods. Andernfalls ist jede Version geeignet</value></data>
-  <data name="EditModpackTooltipDepends" xml:space="preserve"><value>Verschiebe ausgewählte Mods in die Depends-Gruppe</value></data>
-  <data name="EditModpackTooltipRecommends" xml:space="preserve"><value>Verschiebe ausgewählte Mods in die Gruppe "Empfehlungen"</value></data>
-  <data name="EditModpackTooltipSuggests" xml:space="preserve"><value>Verschiebe ausgewählte Mods in die Gruppe "Vorschläge"</value></data>
-  <data name="EditModpackTooltipIgnore" xml:space="preserve"><value>Verschiebe ausgewählte Mods in die Gruppe Ignoriert</value></data>
-  <data name="EditModpackTooltipCancel" xml:space="preserve"><value>Bricht die Modpack-Erstellung ab</value></data>
+  <data name="EditModpackTooltipIncludeVersions" xml:space="preserve"><value>Wenn diese Option aktiviert ist, wird bei jeder Mod die unten angezeigte Version mitgespeichert. Beim Importieren des Modpacks werden dann genau diese Versionen installiert.</value></data>
+  <data name="EditModpackTooltipDepends" xml:space="preserve"><value>Speichere die ausgewählten Mods als Abhängigkeiten im Modpack. Diese Mods werden bei der Installation des Modpacks auf jeden Fall installiert.</value></data>
+  <data name="EditModpackTooltipRecommends" xml:space="preserve"><value>Speichere die ausgewählten Mods als Empfehlungen. Beim Installieren des Modpacks kann der Nutzer diese Mods weglassen.</value></data>
+  <data name="EditModpackTooltipSuggests" xml:space="preserve"><value>Speichere die ausgewählten Mods als Vorschläge. Bei der Installation des Modpacks werden diese Mods angezeigt, der Nutzer muss sie jedoch erst explizit zur Installation auswählen.</value></data>
+  <data name="EditModpackTooltipIgnore" xml:space="preserve"><value>Speichere die ausgewählten Mods NICHT im Modpack. Diese Mods werden nicht sichtbar sein.</value></data>
+  <data name="EditModpackTooltipCancel" xml:space="preserve"><value>Brich die Modpackerstellung ab</value></data>
   <data name="EditModpackTooltipExport" xml:space="preserve"><value>Wähle einen Dateinamen und speichere das Modpack</value></data>
 </root>

--- a/GUI/Properties/Resources.resx
+++ b/GUI/Properties/Resources.resx
@@ -367,16 +367,16 @@ Do you want to allow CKAN to do this? If you click no you won't see this message
   <data name="EditModpackBadKspVersions" xml:space="preserve"><value>Min KSP version must be less than or equal to max KSP version</value></data>
   <data name="EditModpackTooltipIdentifier" xml:space="preserve"><value>Internal name of this modpack; letters, numbers, and dashes only</value></data>
   <data name="EditModpackTooltipName" xml:space="preserve"><value>Publicly visible name of this modpack</value></data>
-  <data name="EditModpackTooltipAbstract" xml:space="preserve"><value>Long description of this modpack</value></data>
+  <data name="EditModpackTooltipAbstract" xml:space="preserve"><value>Short description of this modpack</value></data>
   <data name="EditModpackTooltipVersion" xml:space="preserve"><value>The version number for this modpack</value></data>
   <data name="EditModpackTooltipKspVersionMin" xml:space="preserve"><value>Earliest compatible version of KSP, blank for all</value></data>
   <data name="EditModpackTooltipKspVersionMax" xml:space="preserve"><value>Latest compatible version of KSP, blank for all</value></data>
   <data name="EditModpackTooltipLicense" xml:space="preserve"><value>The licence for this modpack</value></data>
   <data name="EditModpackTooltipIncludeVersions" xml:space="preserve"><value>If checked, the modpack will include the specific versions of the mods shown, otherwise any version will do</value></data>
-  <data name="EditModpackTooltipDepends" xml:space="preserve"><value>Move selected mods to the Depends group</value></data>
-  <data name="EditModpackTooltipRecommends" xml:space="preserve"><value>Move selected mods to the Recommends group</value></data>
-  <data name="EditModpackTooltipSuggests" xml:space="preserve"><value>Move selected mods to the Suggests group</value></data>
-  <data name="EditModpackTooltipIgnore" xml:space="preserve"><value>Move selected mods to the Ignored group</value></data>
+  <data name="EditModpackTooltipDepends" xml:space="preserve"><value>Move selected mods to the Depends group. These mods will definitely be installed.</value></data>
+  <data name="EditModpackTooltipRecommends" xml:space="preserve"><value>Move selected mods to the Recommends group. A user can drop these mods on installation.</value></data>
+  <data name="EditModpackTooltipSuggests" xml:space="preserve"><value>Move selected mods to the Suggests group. These mods will be available for installation, but you have to explicitly select them.</value></data>
+  <data name="EditModpackTooltipIgnore" xml:space="preserve"><value>Move selected mods to the Ignored group. These mods won't be included in the modpack. </value></data>
   <data name="EditModpackTooltipCancel" xml:space="preserve"><value>Abort modpack creation</value></data>
   <data name="EditModpackTooltipExport" xml:space="preserve"><value>Choose a filename and save the modpack</value></data>
 </root>


### PR DESCRIPTION
This is the revised German l10n for https://github.com/KSP-CKAN/CKAN/pull/2971.

You've copied a part of `Localozation/ChooseRecommendedMods.de-DE.resx` and `Localozation/ChooseProvidedMods.de-DE.resx` into `Localozation/Main.de-DE.resx`, not sure why (I guess it was unintentional) . I deleted it again, because it's not needed.

Otherwsie I also changed some English tooltips, it said "Long description" for the abstract, which is actually a short description;
and I added a second explanatory sentence to the relationship button tooltips, because I suspect non-metadata-native users could be confused which relationship will do what and what to choose.