### PR TITLE
German localization for master search bar

### DIFF
--- a/GUI/Controls/EditModSearch.resx
+++ b/GUI/Controls/EditModSearch.resx
@@ -117,74 +117,6 @@
   <resheader name="writer">
     <value>System.Resources.ResXResourceWriter, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
   </resheader>
-  <metadata name="menuStrip2.TrayLocation" type="System.Drawing.Point, System.Drawing, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a">
-    <value>236, 17</value>
-  </metadata>
-  <metadata name="Installed.UserAddedColumn" type="System.Boolean, mscorlib, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089">
-    <value>True</value>
-  </metadata>
-  <metadata name="ModName.UserAddedColumn" type="System.Boolean, mscorlib, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089">
-    <value>True</value>
-  </metadata>
-  <metadata name="Author.UserAddedColumn" type="System.Boolean, mscorlib, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089">
-    <value>True</value>
-  </metadata>
-  <metadata name="InstalledVersion.UserAddedColumn" type="System.Boolean, mscorlib, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089">
-    <value>True</value>
-  </metadata>
-  <metadata name="LatestVersion.UserAddedColumn" type="System.Boolean, mscorlib, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089">
-    <value>True</value>
-  </metadata>
-  <metadata name="SizeCol.UserAddedColumn" type="System.Boolean, mscorlib, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089">
-    <value>True</value>
-  </metadata>
-  <metadata name="Description.UserAddedColumn" type="System.Boolean, mscorlib, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089">
-    <value>True</value>
-  </metadata>
-  <metadata name="ModListContextMenuStrip.TrayLocation" type="System.Drawing.Point, System.Drawing, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a">
-    <value>351, 17</value>
-  </metadata>
-  <data name="$this.Localizable" type="System.Boolean, mscorlib">
-    <value>True</value>
-  </data>
-  <data name="$this.Language" type="System.Globalization.CultureInfo, mscorlib">
-    <value>(Default)</value>
-  </data>
-  <data name="launchKSPToolStripMenuItem.Text" xml:space="preserve"><value>Launch KSP</value></data>
-  <data name="RefreshToolButton.Text" xml:space="preserve"><value>Refresh</value></data>
-  <data name="UpdateAllToolButton.Text" xml:space="preserve"><value>Add available updates</value></data>
-  <data name="ApplyToolButton.Text" xml:space="preserve"><value>Apply changes</value></data>
-  <data name="FilterToolButton.Text" xml:space="preserve"><value>Filter (Compatible)</value></data>
-  <data name="FilterCompatibleButton.Text" xml:space="preserve"><value>Compatible</value></data>
-  <data name="FilterInstalledButton.Text" xml:space="preserve"><value>Installed</value></data>
-  <data name="FilterInstalledUpdateButton.Text" xml:space="preserve"><value>Installed (update available)</value></data>
-  <data name="FilterReplaceableButton.Text" xml:space="preserve"><value>Replaceable</value></data>
-  <data name="FilterCachedButton.Text" xml:space="preserve"><value>Cached</value></data>
-  <data name="FilterUncachedButton.Text" xml:space="preserve"><value>Uncached</value></data>
-  <data name="FilterNewButton.Text" xml:space="preserve"><value>Newly compatible</value></data>
-  <data name="FilterNotInstalledButton.Text" xml:space="preserve"><value>Not installed</value></data>
-  <data name="FilterIncompatibleButton.Text" xml:space="preserve"><value>Incompatible</value></data>
-  <data name="FilterAllButton.Text" xml:space="preserve"><value>All</value></data>
-  <data name="FilterTagsToolButton.Text" xml:space="preserve"><value>Tags</value></data>
-  <data name="FilterLabelsToolButton.Text" xml:space="preserve"><value>Labels</value></data>
-  <data name="NavBackwardToolButton.ToolTipText" xml:space="preserve"><value>Previous selected mod...</value></data>
-  <data name="NavForwardToolButton.ToolTipText" xml:space="preserve"><value>Next selected mod...</value></data>
-  <data name="Installed.HeaderText" xml:space="preserve"><value>    Inst</value></data>
-  <data name="AutoInstalled.HeaderText" xml:space="preserve"><value>Auto-installed</value></data>
-  <data name="UpdateCol.HeaderText" xml:space="preserve"><value>Update</value></data>
-  <data name="ReplaceCol.HeaderText" xml:space="preserve"><value>Replace</value></data>
-  <data name="ModName.HeaderText" xml:space="preserve"><value>Name</value></data>
-  <data name="Author.HeaderText" xml:space="preserve"><value>Author</value></data>
-  <data name="InstalledVersion.HeaderText" xml:space="preserve"><value>Installed version</value></data>
-  <data name="LatestVersion.HeaderText" xml:space="preserve"><value>Latest version</value></data>
-  <data name="KSPCompatibility.HeaderText" xml:space="preserve"><value>Max KSP version</value></data>
-  <data name="SizeCol.HeaderText" xml:space="preserve"><value>Download</value></data>
-  <data name="InstallDate.HeaderText" xml:space="preserve"><value>Install date</value></data>
-  <data name="DownloadCount.HeaderText" xml:space="preserve"><value>Downloads</value></data>
-  <data name="Description.HeaderText" xml:space="preserve"><value>Description</value></data>
-  <data name="reinstallToolStripMenuItem.Text" xml:space="preserve"><value>Reinstall</value></data>
-  <data name="downloadContentsToolStripMenuItem.Text" xml:space="preserve"><value>Download Contents</value></data>
-  <data name="purgeContentsToolStripMenuItem.Text" xml:space="preserve"><value>Purge Contents</value></data>
   <data name="FilterCombinedLabel.Text" xml:space="preserve"><value>Search:</value></data>
   <data name="FilterByNameLabel.Text" xml:space="preserve"><value>Name:</value></data>
   <data name="FilterByAuthorLabel.Text" xml:space="preserve"><value>Author:</value></data>
@@ -194,6 +126,4 @@
   <data name="FilterByRecommendsLabel.Text" xml:space="preserve"><value>Recommends:</value></data>
   <data name="FilterBySuggestsLabel.Text" xml:space="preserve"><value>Suggests:</value></data>
   <data name="FilterByConflictsLabel.Text" xml:space="preserve"><value>Conflicts with:</value></data>
-  <data name="labelsToolStripMenuItem.Text" xml:space="preserve"><value>Labels</value></data>
-  <data name="editLabelsToolStripMenuItem.Text" xml:space="preserve"><value>Edit labels...</value></data>
 </root>

--- a/GUI/Controls/ManageMods.resx
+++ b/GUI/Controls/ManageMods.resx
@@ -185,15 +185,6 @@
   <data name="reinstallToolStripMenuItem.Text" xml:space="preserve"><value>Reinstall</value></data>
   <data name="downloadContentsToolStripMenuItem.Text" xml:space="preserve"><value>Download Contents</value></data>
   <data name="purgeContentsToolStripMenuItem.Text" xml:space="preserve"><value>Purge Contents</value></data>
-  <data name="FilterByAuthorLabel.Text" xml:space="preserve"><value>Filter by author name:</value></data>
-  <data name="FilterByAuthorTextBox.Location" type="System.Drawing.Point, System.Drawing"><value>543, 74</value></data>
-  <data name="FilterByAuthorTextBox.Size" type="System.Drawing.Size, System.Drawing"><value>170, 26</value></data>
-  <data name="FilterByNameLabel.Text" xml:space="preserve"><value>Filter by mod name:</value></data>
-  <data name="FilterByNameTextBox.Location" type="System.Drawing.Point, System.Drawing"><value>160, 74</value></data>
-  <data name="FilterByNameTextBox.Size" type="System.Drawing.Size, System.Drawing"><value>170, 26</value></data>
-  <data name="FilterByDescriptionLabel.Text" xml:space="preserve"><value>Filter by description:</value></data>
-  <data name="FilterByDescriptionTextBox.Location" type="System.Drawing.Point, System.Drawing"><value>912, 74</value></data>
-  <data name="FilterByDescriptionTextBox.Size" type="System.Drawing.Size, System.Drawing"><value>170, 26</value></data>
   <data name="labelsToolStripMenuItem.Text" xml:space="preserve"><value>Labels</value></data>
   <data name="editLabelsToolStripMenuItem.Text" xml:space="preserve"><value>Edit labels...</value></data>
 </root>

--- a/GUI/Localization/de-DE/EditModSearch.de-DE.resx
+++ b/GUI/Localization/de-DE/EditModSearch.de-DE.resx
@@ -117,40 +117,13 @@
   <resheader name="writer">
     <value>System.Resources.ResXResourceWriter, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
   </resheader>
-  <metadata name="menuStrip2.TrayLocation" type="System.Drawing.Point, System.Drawing, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a">
-    <value>236, 17</value>
-  </metadata>
-  <metadata name="Installed.UserAddedColumn" type="System.Boolean, mscorlib, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089">
-    <value>True</value>
-  </metadata>
-  <metadata name="ModName.UserAddedColumn" type="System.Boolean, mscorlib, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089">
-    <value>True</value>
-  </metadata>
-  <metadata name="Author.UserAddedColumn" type="System.Boolean, mscorlib, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089">
-    <value>True</value>
-  </metadata>
-  <metadata name="InstalledVersion.UserAddedColumn" type="System.Boolean, mscorlib, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089">
-    <value>True</value>
-  </metadata>
-  <metadata name="LatestVersion.UserAddedColumn" type="System.Boolean, mscorlib, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089">
-    <value>True</value>
-  </metadata>
-  <metadata name="SizeCol.UserAddedColumn" type="System.Boolean, mscorlib, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089">
-    <value>True</value>
-  </metadata>
-  <metadata name="Description.UserAddedColumn" type="System.Boolean, mscorlib, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089">
-    <value>True</value>
-  </metadata>
-  <metadata name="ModListContextMenuStrip.TrayLocation" type="System.Drawing.Point, System.Drawing, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a">
-    <value>351, 17</value>
-  </metadata>
-  <data name="$this.Localizable" type="System.Boolean, mscorlib">
-    <value>True</value>
-  </data>
-  <data name="$this.Language" type="System.Globalization.CultureInfo, mscorlib">
-    <value>(Default)</value>
-  </data>
-  <data name="FilterByAuthorLabel.Text" xml:space="preserve"><value>Nach Autorenname filtern:</value></data>
-  <data name="FilterByNameLabel.Text" xml:space="preserve"><value>Nach Modname filtern:</value></data>
-  <data name="FilterByDescriptionLabel.Text" xml:space="preserve"><value>Nach Beschreibung filtern:</value></data>
+  <data name="FilterCombinedLabel.Text" xml:space="preserve"><value>Suche:</value></data>
+  <data name="FilterByNameLabel.Text" xml:space="preserve"><value>Name:</value></data>
+  <data name="FilterByAuthorLabel.Text" xml:space="preserve"><value>Autor:</value></data>
+  <data name="FilterByDescriptionLabel.Text" xml:space="preserve"><value>Beschreibung:</value></data>
+  <data name="FilterByLanguageLabel.Text" xml:space="preserve"><value>Sprache:</value></data>
+  <data name="FilterByDependsLabel.Text" xml:space="preserve"><value>Hängt ab von:</value></data>
+  <data name="FilterByRecommendsLabel.Text" xml:space="preserve"><value>Empfiehlt:</value></data>
+  <data name="FilterBySuggestsLabel.Text" xml:space="preserve"><value>Schlägt vor:</value></data>
+  <data name="FilterByConflictsLabel.Text" xml:space="preserve"><value>Hat einen Konflikt mit:</value></data>
 </root>

--- a/GUI/Properties/Resources.de-DE.resx
+++ b/GUI/Properties/Resources.de-DE.resx
@@ -372,4 +372,5 @@ Wenn du auf Nein klickst, siehst du diese Nachricht nicht mehr.</value>
   <data name="EditModpackTooltipIgnore" xml:space="preserve"><value>Speichere die ausgewählten Mods NICHT im Modpack. Diese Mods werden nicht sichtbar sein.</value></data>
   <data name="EditModpackTooltipCancel" xml:space="preserve"><value>Brich die Modpackerstellung ab</value></data>
   <data name="EditModpackTooltipExport" xml:space="preserve"><value>Wähle einen Dateinamen und speichere das Modpack</value></data>
+  <data name="EditModSearchTooltipExpandButton" xml:space="preserve"><value>Detailierte Suchfelder ein-/ausklappen (Strg-Shift-F)</value></data>
 </root>


### PR DESCRIPTION
Here's the German translation for https://github.com/KSP-CKAN/CKAN/pull/3041 .

I went with untranslated search prefixes now. If we ever get feedback on this and decide to change it, I think it would be doable in retrospect.

Also I think some resource files have been messed up a bit.
The `EditModSearch.resx` and `ManageMods.resx` have had duplicate elements. I hope I got that sorted out correctly.