### PR TITLE
Start next download before moving zip; consider queued downloads in total progress

### DIFF
--- a/Core/Net/NetAsyncDownloader.cs
+++ b/Core/Net/NetAsyncDownloader.cs
@@ -364,6 +364,11 @@ namespace CKAN
                 totalBytesLeft += t.bytesLeft;
                 totalSize += t.size;
             }
+            foreach (Net.DownloadTarget t in queuedDownloads.ToList())
+            {
+                totalBytesLeft += t.size;
+                totalSize += t.size;
+            }
 
             int totalPercentage = (int)(((totalSize - totalBytesLeft) * 100) / (totalSize));
 
@@ -412,7 +417,6 @@ namespace CKAN
             {
                 log.InfoFormat("Finished downloading {0}", downloads[index].target.url);
             }
-            onOneCompleted.Invoke(downloads[index].target.url, downloads[index].path, downloads[index].error);
 
             if (throttledHosts.Contains(downloads[index].target.url.Host))
             {
@@ -425,6 +429,8 @@ namespace CKAN
                     DownloadModule(next);
                 }
             }
+
+            onOneCompleted.Invoke(downloads[index].target.url, downloads[index].path, downloads[index].error);
 
             if (++completed_downloads >= downloads.Count + queuedDownloads.Count)
             {


### PR DESCRIPTION
For https://github.com/KSP-CKAN/CKAN/pull/3054

## Motivation
The download progress bar + percentage currently jump around, because they only consider the currently active downloads.
So assuming you have only outstanding downloads from throttled hosts, it hits 100% after every download completes, and the jumps down to a lower value as soon as a new download is started.

We waste time by waiting for `onOneCompleted` before starting the next download from throttled hosts.
`onOneCompleted` has really costly events attached, most of all moving the downloaded zip to the cache and validating it. This can take a lot of time (10+ seconds) for mods >50MB.

## Changes
After adding together the size and bytes left for all the active downloads,
we now also loop  threw `queuedDownloads` and add their `size` to `totalBytesLeft` and `totalSize`.

Moved `onOneCompleted.Invoke()` after the new start-next-download structure. Zips shall be moved in the background!