### PR TITLE
Fix NullReferenceException in KSPCompatComparison for registry-unknown mods

### DIFF
--- a/GUI/Model/GUIMod.cs
+++ b/GUI/Model/GUIMod.cs
@@ -174,6 +174,19 @@ namespace CKAN
             SearchableDescription = mod.SearchableDescription;
             SearchableAuthors     = mod.SearchableAuthors;
 
+            // If they hasn't been set in GUIMod(identifier, ...) (because the mod is not known to the registry,
+            // set them based on the the data we have from the CkanModule.
+            if (KSPCompatibilityVersion == null)
+            {
+                KSPCompatibilityVersion = mod.LatestCompatibleKSP();
+                KSPCompatibility = KSPCompatibilityVersion?.ToYalovString() ?? Properties.Resources.GUIModUnknown;
+                KSPCompatibilityLong = string.Format(
+                    Properties.Resources.GUIModKSPCompatibilityLong,
+                    KSPCompatibility,
+                    mod.version
+                );
+            }
+
             UpdateIsCached();
         }
 
@@ -226,11 +239,6 @@ namespace CKAN
                 KSPCompatibility = KSPCompatibilityVersion?.ToYalovString()
                     ?? Properties.Resources.GUIModUnknown;
                 KSPCompatibilityLong = string.Format(Properties.Resources.GUIModKSPCompatibilityLong, KSPCompatibility, latest_available_for_any_ksp.version);
-            }
-            else
-            {
-                // No idea what this mod is, sorry!
-                KSPCompatibility = KSPCompatibilityLong = Properties.Resources.GUIModUnknown;
             }
 
             if (latest_version != null)


### PR DESCRIPTION
## Problem
When launching ckan.exe compiled from your branch it hangs infinitely at `Updating filters...` for me.
After a very long time of trying to find out why and where (because even setting breakpoints didn't reveal the problem), I let my IDE step line-by-line through the decompiled framework code, and found out that there was a exception which isn't thrown:
```
System.Reflection.TargetInvocationException: Exception has been thrown by the target of an invocation. 
---> System.InvalidOperationException: Failed to compare two elements in the array. 
---> System.NullReferenceException: Object reference not set to an instance of an object
  at CKAN.ManageMods.KSPCompatComparison (System.Windows.Forms.DataGridViewRow a, System.Windows.Forms.DataGridViewRow b) [0x00023] in /GIT/CKAN/GUI/Controls/ManageMods.cs:1278 
  at CKAN.ManageMods+<>c__DisplayClass96_0.<CompareThenByName>b__0 (System.Windows.Forms.DataGridViewRow a, System.Windows.Forms.DataGridViewRow b) [0x00001] in /GIT/CKAN/GUI/Controls/ManageMods.cs:1219 
  at System.Collections.Generic.ArraySortHelper`1[T].InsertionSort (T[] keys, System.Int32 lo, System.Int32 hi, System.Comparison`1[T] comparer) [0x0002a] in <b2b5eee6b3734e9586bbc3ab32e40bc7>:0 
  at System.Collections.Generic.ArraySortHelper`1[T].IntroSort (T[] keys, System.Int32 lo, System.Int32 hi, System.Int32 depthLimit, System.Comparison`1[T] comparer) [0x0004b] in <b2b5eee6b3734e9586bbc3ab32e40bc7>:0 
  at System.Collections.Generic.ArraySortHelper`1[T].IntrospectiveSort (T[] keys, System.Int32 left, System.Int32 length, System.Comparison`1[T] comparer) [0x00013] in <b2b5eee6b3734e9586bbc3ab32e40bc7>:0 
  at System.Collections.Generic.ArraySortHelper`1[T].Sort (T[] keys, System.Int32 index, System.Int32 length, System.Comparison`1[T] comparer) [0x00000] in <b2b5eee6b3734e9586bbc3ab32e40bc7>:0 
   --- End of inner exception stack trace ---
  at System.Collections.Generic.ArraySortHelper`1[T].Sort (T[] keys, System.Int32 index, System.Int32 length, System.Comparison`1[T] comparer) [0x00020] in <b2b5eee6b3734e9586bbc3ab32e40bc7>:0 
  at System.Collections.Generic.List`1[T].Sort (System.Comparison`1[T] comparison) [0x00013] in <b2b5eee6b3734e9586bbc3ab32e40bc7>:0 
  at CKAN.ManageMods.Sort (System.Collections.Generic.IEnumerable`1[T] rows, System.Comparison`1[T] comparison) [0x0004b] in /GIT/CKAN/GUI/Controls/ManageMods.cs:1200 
  at CKAN.ManageMods._SortRowsByColumn (System.Collections.Generic.IEnumerable`1[T] rows) [0x0006b] in /GIT/CKAN/GUI/Controls/ManageMods.cs:1163 
  at CKAN.ManageMods._UpdateFilters () [0x0010d] in /GIT/CKAN/GUI/Controls/ManageMods.cs:976 
  at (wrapper managed-to-native) System.Reflection.RuntimeMethodInfo.InternalInvoke(System.Reflection.RuntimeMethodInfo,object,object[],System.Exception&)
  at System.Reflection.RuntimeMethodInfo.Invoke (System.Object obj, System.Reflection.BindingFlags invokeAttr, System.Reflection.Binder binder, System.Object[] parameters, System.Globalization.CultureInfo culture) [0x0006a] in <b2b5eee6b3734e9586bbc3ab32e40bc7>:0 
   --- End of inner exception stack trace ---
  at System.Reflection.RuntimeMethodInfo.Invoke (System.Object obj, System.Reflection.BindingFlags invokeAttr, System.Reflection.Binder binder, System.Object[] parameters, System.Globalization.CultureInfo culture) [0x00083] in <b2b5eee6b3734e9586bbc3ab32e40bc7>:0 
  at System.Reflection.MethodBase.Invoke (System.Object obj, System.Object[] parameters) [0x00000] in <b2b5eee6b3734e9586bbc3ab32e40bc7>:0 
  at System.Delegate.DynamicInvokeImpl (System.Object[] args) [0x000e7] in <b2b5eee6b3734e9586bbc3ab32e40bc7>:0 
  at System.MulticastDelegate.DynamicInvokeImpl (System.Object[] args) [0x00008] in <b2b5eee6b3734e9586bbc3ab32e40bc7>:0 
  at System.Delegate.DynamicInvoke (System.Object[] args) [0x00000] in <b2b5eee6b3734e9586bbc3ab32e40bc7>:0 
  at System.Windows.Forms.XplatUIDriverSupport.ExecutionCallback (System.Windows.Forms.AsyncMethodData data) [0x00007] in <8637a6a20d8848c3b0482a80613e13f8>:0 
```

## Cause
I found the culprit mod: it's a locally crafted .ckan file I did for testing purposes.
I installed it via "Install from .ckan",
thus it is not in the list of available modules in the registry,
thus `registry.LatestAvailable()` returns `null` for its identifier in the third `GUIMod` constructor (`public GUIMod(string identifier, ...)`), and `latest_available_for_any_ksp` is `null`:
https://github.com/HebaruSan/CKAN/blob/8af1da846acb14d6fede544612f17f310c638966/GUI/Model/GUIMod.cs#L216
thus `GUIMod.KSPCompatibilityVersion` doesn't get assigned:
https://github.com/HebaruSan/CKAN/blob/8af1da846acb14d6fede544612f17f310c638966/GUI/Model/GUIMod.cs#L223-L229
thus `verA` / `verB` are `null` in `KSPCompatComparison`,
thus throwing a `NullReferenceException` when accessing `ver*.IsMajorDefined` (or any other property).

## Solution
Set `KSPCompatibilityVersion`, `KSPCompatibility` and `KSPCompatibilityLong` (not needed, but makes sense) in the second `GUIMod` constructor (`public GUIMod(CkanModule mod, ...)`) to the values from the  `CkanModule` if they haven't been set by the third one.
If the mod is known to the registry (i.e. it is in the `AvailableModules` list), it's already set in the third constructor, potentially with data from a newer-than-installed mod version.