### PR TITLE
Handle null GameInstance gracefully in FindInstallableFiles

### DIFF
--- a/Cmdline/Action/GameInstance.cs
+++ b/Cmdline/Action/GameInstance.cs
@@ -332,7 +332,7 @@ namespace CKAN.CmdLine
                         }
                     }
                 }
-                // Try to use instanceNameOrPath as a path and create a new game isntance.
+                // Try to use instanceNameOrPath as a path and create a new game instance.
                 // If it's valid, go on.
                 else if (Manager.InstanceAt(instanceNameOrPath, newName) is CKAN.GameInstance instance && instance.Valid)
                 {

--- a/Cmdline/Options.cs
+++ b/Cmdline/Options.cs
@@ -375,7 +375,7 @@ namespace CKAN.CmdLine
 
         public SubCommandOptions(string[] args)
         {
-            options = new System.Collections.Generic.List<string>(args).GetRange(1, args.Length - 1);
+            options = new List<string>(args).GetRange(1, args.Length - 1);
         }
     }
 

--- a/Core/Configuration/Win32RegistryConfiguration.cs
+++ b/Core/Configuration/Win32RegistryConfiguration.cs
@@ -1,4 +1,4 @@
- using System;
+using System;
 using System.Collections.Generic;
 using System.Linq;
 using System.IO;

--- a/Core/GameVersionProviders/KspBuildMap.cs
+++ b/Core/GameVersionProviders/KspBuildMap.cs
@@ -84,7 +84,6 @@ namespace CKAN.GameVersionProviders
         /// <summary>
         /// Load a build map
         /// </summary>
-        /// <param name="source">Remote to download builds.json from GitHub (default), Cache to use the data from the last remote refresh, Embedded to use the builds.json built into the exe</param>
         public void Refresh()
         {
             if (TrySetRemoteBuildMap())   return;

--- a/Core/Types/ModuleInstallDescriptor.cs
+++ b/Core/Types/ModuleInstallDescriptor.cs
@@ -338,28 +338,30 @@ namespace CKAN
             // Normalize the path before doing everything else
             string install_to = CKANPathUtils.NormalizePath(this.install_to);
 
-            if (install_to == ksp.game.PrimaryModDirectoryRelative
+            // The installation path cannot contain updirs
+            if (install_to.Contains("/../") || install_to.EndsWith("/.."))
+                throw new BadInstallLocationKraken("Invalid installation path: " + install_to);
+
+            if (ksp == null)
+            {
+                installDir = null;
+            }
+            else if (install_to == ksp.game.PrimaryModDirectoryRelative
                 || install_to.StartsWith($"{ksp.game.PrimaryModDirectoryRelative}/"))
             {
                 // The installation path can be either "GameData" or a sub-directory of "GameData"
-                // but it cannot contain updirs
-                if (install_to.Contains("/../") || install_to.EndsWith("/.."))
-                    throw new BadInstallLocationKraken("Invalid installation path: " + install_to);
-
                 string subDir = install_to.Substring(ksp.game.PrimaryModDirectoryRelative.Length);    // remove "GameData"
                 subDir = subDir.StartsWith("/") ? subDir.Substring(1) : subDir;    // remove a "/" at the beginning, if present
 
                 // Add the extracted subdirectory to the path of KSP's GameData
-                installDir = ksp == null
-                    ? null
-                    : (CKANPathUtils.NormalizePath(ksp.game.PrimaryModDirectory(ksp) + "/" + subDir));
+                installDir = CKANPathUtils.NormalizePath(ksp.game.PrimaryModDirectory(ksp) + "/" + subDir);
             }
             else
             {
                 switch (install_to)
                 {
                     case "GameRoot":
-                        installDir = ksp?.GameDir();
+                        installDir = ksp.GameDir();
                         break;
 
                     default:

--- a/GUI/Main/MainRepo.cs
+++ b/GUI/Main/MainRepo.cs
@@ -19,7 +19,7 @@ namespace CKAN
         {
             if (master_uri == null)
             {
-                master_uri = Main.Instance.CurrentInstance.game.DefaultRepositoryURL;
+                master_uri = Main.Instance.CurrentInstance.game.RepositoryListURL;
             }
 
             string json = Net.DownloadText(master_uri);


### PR DESCRIPTION
See https://github.com/KSP-CKAN/CKAN/pull/3223#discussion_r546964409

I still think the code in `FindInstallableFiles()` should handle a null `GameInstace ksp` parameter gracefully, especially since it's promised in its docstring:

> If a KSP instance is provided, it will be used to generate output paths, otherwise these will be null.

This adds a new `if (ksp == null)` to explicitly set `installDir` to null and thus circumvents any possible `NullReferenceException`. Two unnecessary null checks have been removed.

The "updir" sanity check has been moved up a few lines, since it can also do its job with a null `ksp`, and, while the Spec leaves some room for interpretation, because I think it applies to all possible `install_to` directives.